### PR TITLE
feat: new onEvent callback for user land logging of server calls

### DIFF
--- a/src/lib/event-emitter.ts
+++ b/src/lib/event-emitter.ts
@@ -1,0 +1,120 @@
+import { ServerResponse, type IncomingMessage } from "node:http";
+import {
+  type McpErrorEvent,
+  type McpEvent,
+  type McpRequestEvent,
+  type McpSessionEvent,
+  createEvent,
+} from "./log-helper";
+
+export class EventEmittingResponse extends ServerResponse {
+  private onEvent?: (event: McpEvent) => void;
+  private sessionId?: string;
+  private requestId: string;
+  private startTime: number;
+
+  constructor(
+    req: IncomingMessage,
+    onEvent?: (event: McpEvent) => void,
+    sessionId?: string
+  ) {
+    super(req);
+    this.onEvent = onEvent;
+    this.sessionId = sessionId;
+    this.requestId = crypto.randomUUID();
+    this.startTime = Date.now();
+  }
+
+  emitEvent(event: Omit<McpEvent, "timestamp" | "sessionId" | "requestId">) {
+    if (this.onEvent) {
+      this.onEvent(
+        createEvent({
+          ...event,
+          sessionId: this.sessionId,
+          requestId: this.requestId,
+        } as Omit<McpEvent, "timestamp">)
+      );
+    }
+  }
+
+  startSession(
+    transport: "SSE" | "HTTP",
+    clientInfo?: { userAgent?: string; ip?: string }
+  ) {
+    this.emitEvent({
+      type: "SESSION_STARTED",
+      transport,
+      clientInfo,
+    } as Omit<McpSessionEvent, "timestamp" | "sessionId" | "requestId">);
+  }
+
+  endSession(transport: "SSE" | "HTTP") {
+    this.emitEvent({
+      type: "SESSION_ENDED",
+      transport,
+    } as Omit<McpSessionEvent, "timestamp" | "sessionId" | "requestId">);
+  }
+
+  requestReceived(method: string, parameters?: unknown) {
+    this.emitEvent({
+      type: "REQUEST_RECEIVED",
+      method,
+      parameters,
+      status: "success",
+    } as Omit<McpRequestEvent, "timestamp" | "sessionId" | "requestId">);
+  }
+
+  requestCompleted(method: string, result?: unknown, error?: Error | string) {
+    this.emitEvent({
+      type: "REQUEST_COMPLETED",
+      method,
+      result,
+      duration: Date.now() - this.startTime,
+      status: error ? "error" : "success",
+    } as Omit<McpRequestEvent, "timestamp" | "sessionId" | "requestId">);
+
+    if (error) {
+      this.error(error, `Error executing request ${method}`, "request");
+    }
+  }
+
+  error(
+    error: Error | string,
+    context?: string,
+    source: McpErrorEvent["source"] = "system",
+    severity: McpErrorEvent["severity"] = "error"
+  ) {
+    this.emitEvent({
+      type: "ERROR",
+      error,
+      context,
+      source,
+      severity,
+    } as Omit<McpErrorEvent, "timestamp" | "sessionId" | "requestId">);
+  }
+
+  end(
+    chunk?: unknown,
+    encoding?: BufferEncoding | (() => void),
+    cb?: () => void
+  ): this {
+    let finalChunk = chunk;
+    let finalEncoding = encoding;
+    let finalCallback = cb;
+
+    if (typeof chunk === "function") {
+      finalCallback = chunk as () => void;
+      finalChunk = undefined;
+      finalEncoding = undefined;
+    } else if (typeof encoding === "function") {
+      finalCallback = encoding as () => void;
+      finalEncoding = undefined;
+    }
+
+    return super.end(
+      finalChunk as string | Buffer,
+      finalEncoding as BufferEncoding,
+      finalCallback
+    );
+  }
+}

--- a/src/lib/log-helper.ts
+++ b/src/lib/log-helper.ts
@@ -1,10 +1,8 @@
 export type McpEventType =
   | "SESSION_STARTED" // When a new client session begins (either HTTP or SSE)
   | "SESSION_ENDED" // When a client session ends (SSE disconnection)
-  | "TOOL_CALLED" // When a tool is invoked by the client
-  | "TOOL_COMPLETED" // When a tool execution completes
-  | "FUNCTION_CALLED" // When a function is called by the client
-  | "FUNCTION_COMPLETED" // When a function call completes
+  | "REQUEST_RECEIVED" // When a request is received from the client
+  | "REQUEST_COMPLETED" // When a request completes
   | "ERROR"; // When an error occurs during any operation
 
 export interface McpEventBase {
@@ -23,21 +21,12 @@ export interface McpSessionEvent extends McpEventBase {
   };
 }
 
-export interface McpToolEvent extends McpEventBase {
-  type: "TOOL_CALLED" | "TOOL_COMPLETED";
-  toolName: string;
+export interface McpRequestEvent extends McpEventBase {
+  type: "REQUEST_RECEIVED" | "REQUEST_COMPLETED";
+  method: string;
   parameters?: unknown;
   result?: unknown;
-  duration?: number; // For TOOL_COMPLETED events
-  status: "success" | "error";
-}
-
-export interface McpFunctionEvent extends McpEventBase {
-  type: "FUNCTION_CALLED" | "FUNCTION_COMPLETED";
-  functionName: string;
-  parameters?: unknown;
-  result?: unknown;
-  duration?: number; // For FUNCTION_COMPLETED events
+  duration?: number; // For REQUEST_COMPLETED events
   status: "success" | "error";
 }
 
@@ -45,15 +34,11 @@ export interface McpErrorEvent extends McpEventBase {
   type: "ERROR";
   error: Error | string;
   context?: string;
-  source: "tool" | "function" | "session" | "system";
+  source: "request" | "session" | "system";
   severity: "warning" | "error" | "fatal";
 }
 
-export type McpEvent =
-  | McpSessionEvent
-  | McpToolEvent
-  | McpFunctionEvent
-  | McpErrorEvent;
+export type McpEvent = McpSessionEvent | McpRequestEvent | McpErrorEvent;
 
 export function createEvent<T extends McpEvent>(
   event: Omit<T, "timestamp">

--- a/src/lib/log-helper.ts
+++ b/src/lib/log-helper.ts
@@ -1,0 +1,65 @@
+export type McpEventType =
+  | "SESSION_STARTED" // When a new client session begins (either HTTP or SSE)
+  | "SESSION_ENDED" // When a client session ends (SSE disconnection)
+  | "TOOL_CALLED" // When a tool is invoked by the client
+  | "TOOL_COMPLETED" // When a tool execution completes
+  | "FUNCTION_CALLED" // When a function is called by the client
+  | "FUNCTION_COMPLETED" // When a function call completes
+  | "ERROR"; // When an error occurs during any operation
+
+export interface McpEventBase {
+  type: McpEventType;
+  timestamp: number;
+  sessionId?: string;
+  requestId?: string; // To track individual requests within a session
+}
+
+export interface McpSessionEvent extends McpEventBase {
+  type: "SESSION_STARTED" | "SESSION_ENDED";
+  transport: "SSE" | "HTTP";
+  clientInfo?: {
+    userAgent?: string;
+    ip?: string;
+  };
+}
+
+export interface McpToolEvent extends McpEventBase {
+  type: "TOOL_CALLED" | "TOOL_COMPLETED";
+  toolName: string;
+  parameters?: unknown;
+  result?: unknown;
+  duration?: number; // For TOOL_COMPLETED events
+  status: "success" | "error";
+}
+
+export interface McpFunctionEvent extends McpEventBase {
+  type: "FUNCTION_CALLED" | "FUNCTION_COMPLETED";
+  functionName: string;
+  parameters?: unknown;
+  result?: unknown;
+  duration?: number; // For FUNCTION_COMPLETED events
+  status: "success" | "error";
+}
+
+export interface McpErrorEvent extends McpEventBase {
+  type: "ERROR";
+  error: Error | string;
+  context?: string;
+  source: "tool" | "function" | "session" | "system";
+  severity: "warning" | "error" | "fatal";
+}
+
+export type McpEvent =
+  | McpSessionEvent
+  | McpToolEvent
+  | McpFunctionEvent
+  | McpErrorEvent;
+
+export function createEvent<T extends McpEvent>(
+  event: Omit<T, "timestamp">
+): T {
+  return {
+    ...event,
+    timestamp: Date.now(),
+  } as T;
+}


### PR DESCRIPTION
StatelessHttp:
- REQUEST_COMPLETED
-- covers every time the server is invoked for something: initialized, tools/list, tools/call

SSE:
- SESSION_STARTED
- SESSION_ENDED
- REQUEST_COMPLETED
-- covers all the invocations as well as when a connection is started/ ended