### PR TITLE
Fix status code for some errors

### DIFF
--- a/.changeset/famous-foxes-kneel.md
+++ b/.changeset/famous-foxes-kneel.md
@@ -1,0 +1,5 @@
+---
+"@vercel/mcp-adapter": patch
+---
+
+Fix HTTP status code for some errors


### PR DESCRIPTION
We call both `res.writeHead` and `res.statusCode` to set a custom HTTP response code, however the response wrapper was neglecting the HTTP status codes set by `res.statusCode`.

