### PR TITLE
Pass AuthInfo from middleware to Mcp Server + Error handling

### DIFF
--- a/src/next/auth-wrapper.ts
+++ b/src/next/auth-wrapper.ts
@@ -1,40 +1,96 @@
+import { InvalidTokenError, InsufficientScopeError, ServerError } from '@modelcontextprotocol/sdk/server/auth/errors';
+import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types';
+
+export interface McpAuthOptions {
+  /**
+   * Optional, scopes that the token must have.
+   */
+  requiredScopes?: string[];
+
+  /**
+   * Optional, resource metadata path to include in WWW-Authenticate header.
+   */
+  resourceMetadataPath?: string;
+}
+
 export function withMcpAuth(
   handler: (req: Request) => Promise<Response>,
-  verifyToken: (req: Request, token: string) => Promise<boolean>,
-  oauthResourcePath = "/.well-known/oauth-protected-resource"
+  verifyToken: (req: Request, token: string) => Promise<AuthInfo>,
+  options: McpAuthOptions = {
+    resourceMetadataPath: "/.well-known/oauth-protected-resource"
+  }
 ) {
   return async (req: Request) => {
-    const origin = new URL(req.url).origin;
+    try {
+      if (!req.headers.get("Authorization")) {
+        throw new InvalidTokenError("Missing Authorization header");
+      }
 
-    if (!req.headers.get("Authorization")) {
-      return new Response(null, {
-        status: 401,
-        headers: {
-          "WWW-Authenticate": `Bearer resource_metadata=${origin}${oauthResourcePath}`,
-        },
-      });
+      const authHeader = req.headers.get("Authorization");
+      const [type, token] = authHeader?.split(" ") || [];
+
+      if (type?.toLowerCase() !== "bearer" || !token) {
+        throw new InvalidTokenError("Invalid Authorization header format, expected 'Bearer TOKEN'");
+      }
+
+      const authInfo = await verifyToken(req, token);
+
+      // Check if token has the required scopes (if any)
+      if (options.requiredScopes?.length) {
+        const hasAllScopes = options.requiredScopes.every(scope =>
+          authInfo.scopes.includes(scope)
+        );
+
+        if (!hasAllScopes) {
+          throw new InsufficientScopeError("Insufficient scope");
+        }
+      }
+
+      // Check if the token is expired
+      if (authInfo.expiresAt && authInfo.expiresAt < Date.now() / 1000) {
+        throw new InvalidTokenError("Token has expired");
+      }
+
+      // Set auth info on the request object after successful verification
+      (req as any).auth = authInfo;
+
+      return handler(req);
+    } catch (error) {
+      const origin = new URL(req.url).origin;
+      const resourceMetadataUrl = options.resourceMetadataPath || `${origin}/.well-known/oauth-protected-resource`;
+      if (error instanceof InvalidTokenError) {
+        return new Response(JSON.stringify(error.toResponseObject()), {
+          status: 401,
+          headers: {
+            "WWW-Authenticate": `Bearer error="${error.errorCode}", error_description="${error.message}", resource_metadata="${resourceMetadataUrl}"`,
+            "Content-Type": "application/json"
+          }
+        });
+      } else if (error instanceof InsufficientScopeError) {
+        return new Response(JSON.stringify(error.toResponseObject()), {
+          status: 403,
+          headers: {
+            "WWW-Authenticate": `Bearer error="${error.errorCode}", error_description="${error.message}", resource_metadata="${resourceMetadataUrl}"`,
+            "Content-Type": "application/json"
+          }
+        });
+      } else if (error instanceof ServerError) {
+        return new Response(JSON.stringify(error.toResponseObject()), {
+          status: 500,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        });
+      } else {
+        console.error("Unexpected error authenticating bearer token:", error);
+        const serverError = new ServerError("Internal Server Error");
+        return new Response(JSON.stringify(serverError.toResponseObject()), {
+          status: 500,
+          headers: {
+            "Content-Type": "application/json"
+          }
+        });
+      }
     }
-
-    const authHeader = req.headers.get("Authorization");
-    const token = authHeader?.split(" ")[1];
-
-    if (!token) {
-      throw new Error(
-        `Invalid authorization header value, expected Bearer <token>, received ${authHeader}`
-      );
-    }
-
-    const isAuthenticated = await verifyToken(req, token);
-
-    if (!isAuthenticated) {
-      return new Response(JSON.stringify({ error: "Unauthorized" }), {
-        status: 401,
-        headers: {
-          "WWW-Authenticate": `Bearer resource_metadata=${origin}${oauthResourcePath}`,
-        },
-      });
-    }
-
-    return handler(req);
   };
 }

--- a/src/next/auth-wrapper.ts
+++ b/src/next/auth-wrapper.ts
@@ -1,6 +1,12 @@
 import { InvalidTokenError, InsufficientScopeError, ServerError } from '@modelcontextprotocol/sdk/server/auth/errors';
 import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types';
 
+// Extend the Request type to include auth info
+declare global {
+  interface Request {
+    auth?: AuthInfo;
+  }
+}
 export interface McpAuthOptions {
   /**
    * Optional, scopes that the token must have.
@@ -33,7 +39,15 @@ export function withMcpAuth(
         throw new InvalidTokenError("Invalid Authorization header format, expected 'Bearer TOKEN'");
       }
 
-      const authInfo = await verifyToken(req, token);
+      let authInfo: AuthInfo;
+      try {
+        authInfo = await verifyToken(req, token);
+      } catch (error) {
+        // Handle any error from verifyToken as a 401
+        throw new InvalidTokenError(
+          error instanceof Error ? error.message : "Failed to verify token"
+        );
+      }
 
       // Check if token has the required scopes (if any)
       if (options.requiredScopes?.length) {
@@ -52,12 +66,13 @@ export function withMcpAuth(
       }
 
       // Set auth info on the request object after successful verification
-      (req as any).auth = authInfo;
+      req.auth = authInfo;
 
       return handler(req);
     } catch (error) {
       const origin = new URL(req.url).origin;
       const resourceMetadataUrl = options.resourceMetadataPath || `${origin}/.well-known/oauth-protected-resource`;
+      
       if (error instanceof InvalidTokenError) {
         return new Response(JSON.stringify(error.toResponseObject()), {
           status: 401,

--- a/src/next/mcp-api-handler.ts
+++ b/src/next/mcp-api-handler.ts
@@ -20,6 +20,7 @@ import type {
 } from "../lib/log-helper";
 import { createEvent } from "../lib/log-helper";
 import { EventEmittingResponse } from "../lib/event-emitter.js";
+import { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types";
 
 interface SerializedRequest {
   requestId: string;
@@ -310,7 +311,9 @@ export function initializeMcpApiHandler(
           url: req.url,
           headers: Object.fromEntries(req.headers),
           body: bodyContent,
+          auth: (req as any).auth, // Use the auth info that should already be set by withMcpAuth
         });
+        
 
         // Create a response that will emit events
         const wrappedRes = new EventEmittingResponse(
@@ -618,19 +621,21 @@ interface FakeIncomingMessageOptions {
   url?: string;
   headers?: IncomingHttpHeaders;
   body?: BodyType;
+  auth?: AuthInfo;
   socket?: Socket;
 }
 
 // Create a fake IncomingMessage
 function createFakeIncomingMessage(
   options: FakeIncomingMessageOptions = {}
-): IncomingMessage {
+): IncomingMessage & { auth?: AuthInfo } {
   const {
     method = "GET",
     url = "/",
     headers = {},
     body = null,
     socket = new Socket(),
+    auth,
   } = options;
 
   // Create a readable stream that will be used as the base for IncomingMessage
@@ -654,12 +659,15 @@ function createFakeIncomingMessage(
   }
 
   // Create the IncomingMessage instance
-  const req = new IncomingMessage(socket);
+  const req = new IncomingMessage(socket) as IncomingMessage & { auth?: AuthInfo };
 
   // Set the properties
   req.method = method;
   req.url = url;
   req.headers = headers;
+  if (auth) {
+    req.auth = auth;
+  }
 
   // Copy over the stream methods
   req.push = readable.push.bind(readable);

--- a/src/next/mcp-api-handler.ts
+++ b/src/next/mcp-api-handler.ts
@@ -311,7 +311,7 @@ export function initializeMcpApiHandler(
           url: req.url,
           headers: Object.fromEntries(req.headers),
           body: bodyContent,
-          auth: (req as any).auth, // Use the auth info that should already be set by withMcpAuth
+          auth: req.auth, // Use the auth info that should already be set by withMcpAuth
         });
         
 


### PR DESCRIPTION
A common use case when building Mcp Servers is to pass the auth info from the OAuth token through to the Mcp Server tool call. This PR adjust the middleware to set the `auth` object on the request so that it's automatically handled, as implemented in the Anthropic Mcp TS SDK [here](https://github.com/modelcontextprotocol/typescript-sdk/pull/166) and [here](https://github.com/modelcontextprotocol/typescript-sdk/pull/399).

- [x] Streamable HTTP
- [ ] SSE