### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ The above set up snippet will then look like:
 "remote-example": {
   "command": "npx",
   "args": [
-    "mcp-remote",
     "-y",
+    "mcp-remote",
     "http://localhost:3000/api/mcp" // this is your app/api/[transport]/route.ts
   ]
 }
@@ -95,8 +95,8 @@ In order to add an MCP server to Claude Desktop you need to edit the configurati
 "remote-example": {
   "command": "npx",
   "args": [
-    "mcp-remote",
     "-y",
+    "mcp-remote",
     "http://localhost:3000/api/mcp" // this is your app/api/[transport]/route.ts
   ]
 }


### PR DESCRIPTION
Corrects the argument order for the ⁠`npx` command when using `⁠mcp-remote`.

After half an hour of not understanding why neither Claude Desktop, Cursor, nor Claude Code could connect to MCP, when everything was working fine from the CLI, I finally noticed the mistake 😅

The previous ordering was incorrect, passing ⁠`-y` as an argument to the ⁠`mcp-remote` script instead of ⁠`npx`
https://www.npmjs.com/package/mcp-remote#flags