### PR TITLE
chore: get tests working again

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest watch",
     "version-packages": "changeset version",
     "changeset": "changeset",
     "release": "pnpm build && changeset publish"

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -10,7 +10,7 @@ import type { AddressInfo } from "node:net";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { createMcpHandler } from "../src/index";
-import { withMcpAuth } from "../src/next/auth-wrapper";
+import { withMcpAuth } from "../src/auth/auth-wrapper";
 
 describe("e2e", () => {
   let server: Server;

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateEndpoints } from '../src/next/mcp-api-handler';
+import { calculateEndpoints } from '../src/handler/mcp-api-handler';
 
 describe('calculateEndpoints', () => {
   it('derives all endpoints from basePath', () => {


### PR DESCRIPTION
Some import paths in the tests needed updating.

Also, WDYT about letting `vitest run` be the default `test` script, and having a separate one (`test:watch`) for `vitest watch`?