### PR TITLE
feat(protectedResourceHandler): support more protected resource identifiers

### DIFF
--- a/src/auth/auth-metadata.ts
+++ b/src/auth/auth-metadata.ts
@@ -25,11 +25,11 @@ export function protectedResourceHandler({
     authServerUrls: string[];
 }) {
     return (req: Request) => {
-        const origin = new URL(req.url).origin;
+        const resource = req.url.toString().replace("/.well-known/oauth-protected-resource", "");
 
         const metadata = generateProtectedResourceMetadata({
             authServerUrls,
-            resourceUrl: origin,
+            resourceUrl: resource,
         });
 
         return new Response(JSON.stringify(metadata), {

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { protectedResourceHandler } from "../src/index";
+
+describe("auth", () => {
+  describe("resource metadata URL to resource identifier mapping", () => {
+    const handler = protectedResourceHandler({
+      authServerUrls: ["https://auth-server.com"],
+    });
+
+    const testCases = [
+      // Default well-known URI suffix (oauth-protected-resource)
+      {
+        resourceMetadata: 'https://resource-server.com/.well-known/oauth-protected-resource',
+        resource: 'https://resource-server.com',
+      },
+      {
+        resourceMetadata: 'https://resource-server.com/.well-known/oauth-protected-resource/my-resource',
+        resource: 'https://resource-server.com/my-resource',
+      },
+      {
+        resourceMetadata: 'https://resource-server.com/.well-known/oauth-protected-resource/foo/bar',
+        resource: 'https://resource-server.com/foo/bar',
+      },
+      // Ensure ports work
+      {
+        resourceMetadata: 'https://resource-server.com:8443/.well-known/oauth-protected-resource',
+        resource: 'https://resource-server.com:8443',
+      },
+      // Example well-known URI suffix from RFC 9728 (example-protected-resource)
+      {
+        resourceMetadata: 'https://resource-server.com/.well-known/example-protected-resource',
+        resource: 'https://resource-server.com',
+      },
+      {
+        resourceMetadata: 'https://resource-server.com/.well-known/example-protected-resource/my-resource',
+        resource: 'https://resource-server.com/my-resource',
+      },
+    ] as const;
+
+    testCases.forEach(testCase => {
+      it(`${testCase.resourceMetadata} → ${testCase.resource}`, async () => {
+        const req = new Request(testCase.resourceMetadata);
+        const res = handler(req); 
+        const json = await res.json();
+        expect(json.resource).toBe(testCase.resource);
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
Assume I setup my MCP server at `https://example.com/api/mcp`.

I could consider all of `https://example.com` to be my protected resource, as we currently do in the README.md. In this case, the following resource metadata URL, the returned resource identifier (`resource`), and the WWW-Authenticate header are correct:

```
https://example.com/.well-known/oauth-protected-resource
```

```json
{
  "resource": "https://example.com",
  "authorization_servers": ["https://authorization-server.com"]
}
```

```
WWW-Authenticate: Bearer error="invalid_token",
  error_description="No authorization provided",
  resource_metadata="https://example.com/.well-known/oauth-protected-resource"
```

However, IIUC [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728.html), I could also consider `https://example.com/api/mcp` to be the protected resource. In this case, the following resource metadata URL, the returned resource identifier (`resource`), and the WWW-Authenticate header would be correct:

```
https://example.com/.well-known/oauth-protected-resource/api/mcp
```

```json
{
  "resource": "https://example.com/api/mcp",
  "authorization_servers": ["https://authorization-server.com"]
}
```

```
WWW-Authenticate: Bearer error="invalid_token",
  error_description="No authorization provided",
  resource_metadata="https://example.com/.well-known/oauth-protected-resource/api/mcp"
```

In order to support this, we'd call `protectedResourceHandler` from

```
app/.well-known/oauth-protected-resource/api/mcp/route.ts
```

and update the way that the resource identifier (`resource`) is computed.

Instead of using

```ts
new URL(req.url).origin
```

we could do

```ts
req.url.toString().replace("/.well-known/oauth-protected-resource", "")
```

which should work for both cases:

| `req.url` | Resource Identifier |
|:--- |:--- |
| https://example.com/.well-known/oauth-protected-resource | https://example.com |
| https://example.com/.well-known/oauth-protected-resource/api/mcp | https://example.com/api/mcp |

Also, I kept the variable name `resourceUrl`; however, I don't think that's semantically correct:

https://github.com/vercel/mcp-adapter/blob/592125c3c567213fdf5e5ca5cc7e7b1a090469e0/src/auth/auth-metadata.ts#L52

A resource server can host multiple protected resources, and so I think the variable would be better named `resource` and documented as something like this:

```
 * @param resource - the protected resource identifier this metadata pertains to
```

If we agree, I could open a follow-up PR to address this.