### PR TITLE
Add missing Zod import in README authorization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The MCP adapter supports the [MCP Authorization Specification](https://modelcont
 // app/api/[transport]/route.ts
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import { createMcpHandler, withMcpAuth } from "mcp-handler";
+import { z } from "zod";
 
 // Create your handler as normal
 const handler = createMcpHandler(


### PR DESCRIPTION
## Summary

This PR updates the README to include the missing ‎`zod` import in the authorization example. Previously, the example used the ‎`z` object without showing where it was imported from, which could lead to confusion for users following the documentation.

## Details
 • Added ‎`import { z } from "zod";` to the code snippet in the authorization section of the README.
 • The example is now fully self-contained, so users can copy and use the code directly without needing to add missing imports or make further changes.

## Motivation

Including the missing import improves the clarity and usability of the documentation, making it easier for developers to implement authorization using the MCP adapter as described.