### PR TITLE
Update examples to export handler as DELETE

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ const handler = createMcpHandler(
     verboseLogs: true,
   }
 );
-export { handler as GET, handler as POST };
+export { handler as GET, handler as POST, handler as DELETE };
 ```
 
 ### Advanced Routing
@@ -304,7 +304,7 @@ const authHandler = withMcpAuth(handler, verifyToken, {
   resourceMetadataPath: "/.well-known/oauth-protected-resource", // Optional: Custom metadata path
 });
 
-export { authHandler as GET, authHandler as POST };
+export { authHandler as GET, authHandler as POST, authHandler as DELETE };
 ```
 
 ### OAuth Protected Resource Metadata

--- a/examples/auth/route.ts
+++ b/examples/auth/route.ts
@@ -85,5 +85,5 @@ const authHandler = withMcpAuth(handler, verifyToken, {
   resourceMetadataPath: "/.well-known/oauth-protected-resource",
 });
 
-// Export the handler for both GET and POST methods
-export { authHandler as GET, authHandler as POST };
+// Export the handler for GET, POST, and DELETE HTTP methods
+export { authHandler as GET, authHandler as POST, authHandler as DELETE };

--- a/examples/route.ts
+++ b/examples/route.ts
@@ -27,4 +27,4 @@ const handler = createMcpRouteHandler(
   }
 );
 
-export { handler as GET, handler as POST };
+export { handler as GET, handler as POST, handler as DELETE };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,7 +39,7 @@ const handler = createMcpHandler(
   }
 );
 
-export { handler as GET, handler as POST };
+export { handler as GET, handler as POST, handler as DELETE };
 `;
 
 async function detectPackageManager(): Promise<


### PR DESCRIPTION
Make sure to handle all MCP HTTP methods with mcp-handler when using it.

This will also ensure it returns JSON-RPC error response.