### PR TITLE
fix: respect proxy headers when constructing resource URLs in withMcpAuth and protectedResourceHandler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,3 +13,5 @@ export {
   generateProtectedResourceMetadata,
   metadataCorsOptionsRequestHandler,
 } from "./auth/auth-metadata";
+
+export { getPublicOrigin, getPublicUrl } from "./lib/url";

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,83 @@
+/**
+ * Get the public-facing origin from a request, respecting proxy headers.
+ *
+ * When running behind a reverse proxy (e.g., nginx, Vercel, Cloudflare),
+ * the `req.url` typically reflects the internal URL (e.g., http://localhost:3000).
+ * This function reconstructs the public-facing origin using standard proxy headers.
+ *
+ * Header precedence:
+ * 1. X-Forwarded-Host + X-Forwarded-Proto (most common)
+ * 2. Forwarded header (RFC 7239)
+ * 3. Falls back to req.url origin
+ *
+ * @param req - The incoming request
+ * @returns The public-facing origin (e.g., "https://example.org")
+ */
+export function getPublicOrigin(req: Request): string {
+  const forwardedHost = req.headers.get("x-forwarded-host");
+  const forwardedProto = req.headers.get("x-forwarded-proto");
+
+  // If we have X-Forwarded-Host, construct origin from forwarded headers
+  if (forwardedHost) {
+    // X-Forwarded-Host can contain multiple comma-separated values; use the first (leftmost)
+    const host = forwardedHost.split(",")[0].trim();
+    // X-Forwarded-Proto can also be comma-separated
+    const proto = forwardedProto?.split(",")[0].trim() || "https";
+    return `${proto}://${host}`;
+  }
+
+  // Check RFC 7239 Forwarded header (less common but standardized)
+  const forwarded = req.headers.get("forwarded");
+  if (forwarded) {
+    const parsed = parseForwardedHeader(forwarded);
+    if (parsed.host) {
+      const proto = parsed.proto || "https";
+      return `${proto}://${parsed.host}`;
+    }
+  }
+
+  // Fallback to req.url origin
+  return new URL(req.url).origin;
+}
+
+/**
+ * Get the public-facing URL from a request, respecting proxy headers.
+ *
+ * @param req - The incoming request
+ * @returns The public-facing URL with the correct origin
+ */
+export function getPublicUrl(req: Request): URL {
+  const url = new URL(req.url);
+  const publicOrigin = getPublicOrigin(req);
+
+  // Construct a new URL with the public origin but preserve pathname, search, and hash
+  const result = new URL(url.pathname + url.search + url.hash, publicOrigin);
+  return result;
+}
+
+/**
+ * Parse the RFC 7239 Forwarded header.
+ * Example: "for=192.0.2.60;proto=https;host=example.com"
+ */
+function parseForwardedHeader(
+  forwarded: string
+): { host?: string; proto?: string } {
+  const result: { host?: string; proto?: string } = {};
+
+  // The header can contain multiple comma-separated forwarded elements; use the first
+  const firstElement = forwarded.split(",")[0];
+
+  // Parse key=value pairs separated by semicolons
+  const pairs = firstElement.split(";");
+  for (const pair of pairs) {
+    const [key, value] = pair.split("=").map((s) => s.trim().toLowerCase());
+    if (key === "host" && value) {
+      // Remove surrounding quotes if present
+      result.host = value.replace(/^"|"$/g, "");
+    } else if (key === "proto" && value) {
+      result.proto = value.replace(/^"|"$/g, "");
+    }
+  }
+
+  return result;
+}

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -40,10 +40,101 @@ describe("auth", () => {
     testCases.forEach(testCase => {
       it(`${testCase.resourceMetadata} → ${testCase.resource}`, async () => {
         const req = new Request(testCase.resourceMetadata);
-        const res = handler(req); 
+        const res = handler(req);
         const json = await res.json();
         expect(json.resource).toBe(testCase.resource);
       });
+    });
+  });
+
+  describe("proxy header support", () => {
+    const handler = protectedResourceHandler({
+      authServerUrls: ["https://auth-server.com"],
+    });
+
+    it("uses X-Forwarded-Host and X-Forwarded-Proto headers", async () => {
+      const req = new Request("http://localhost:3000/.well-known/oauth-protected-resource", {
+        headers: {
+          "X-Forwarded-Host": "example.org",
+          "X-Forwarded-Proto": "https",
+        },
+      });
+      const res = handler(req);
+      const json = await res.json();
+      expect(json.resource).toBe("https://example.org");
+    });
+
+    it("handles X-Forwarded-Host with multiple values (uses first)", async () => {
+      const req = new Request("http://localhost:3000/.well-known/oauth-protected-resource", {
+        headers: {
+          "X-Forwarded-Host": "example.org, proxy1.internal, proxy2.internal",
+          "X-Forwarded-Proto": "https",
+        },
+      });
+      const res = handler(req);
+      const json = await res.json();
+      expect(json.resource).toBe("https://example.org");
+    });
+
+    it("defaults to https when X-Forwarded-Proto is missing", async () => {
+      const req = new Request("http://localhost:3000/.well-known/oauth-protected-resource", {
+        headers: {
+          "X-Forwarded-Host": "example.org",
+        },
+      });
+      const res = handler(req);
+      const json = await res.json();
+      expect(json.resource).toBe("https://example.org");
+    });
+
+    it("uses RFC 7239 Forwarded header", async () => {
+      const req = new Request("http://localhost:3000/.well-known/oauth-protected-resource", {
+        headers: {
+          "Forwarded": "host=example.org;proto=https",
+        },
+      });
+      const res = handler(req);
+      const json = await res.json();
+      expect(json.resource).toBe("https://example.org");
+    });
+
+    it("preserves path when using proxy headers", async () => {
+      const req = new Request("http://localhost:3000/.well-known/oauth-protected-resource/my-resource", {
+        headers: {
+          "X-Forwarded-Host": "example.org",
+          "X-Forwarded-Proto": "https",
+        },
+      });
+      const res = handler(req);
+      const json = await res.json();
+      expect(json.resource).toBe("https://example.org/my-resource");
+    });
+
+    it("falls back to req.url when no proxy headers present", async () => {
+      const req = new Request("https://direct-server.com/.well-known/oauth-protected-resource");
+      const res = handler(req);
+      const json = await res.json();
+      expect(json.resource).toBe("https://direct-server.com");
+    });
+  });
+
+  describe("explicit resourceUrl override", () => {
+    it("uses explicit resourceUrl when provided", async () => {
+      const handler = protectedResourceHandler({
+        authServerUrls: ["https://auth-server.com"],
+        resourceUrl: "https://my-public-domain.com",
+      });
+
+      const req = new Request("http://localhost:3000/.well-known/oauth-protected-resource", {
+        headers: {
+          "X-Forwarded-Host": "different-proxy.org",
+          "X-Forwarded-Proto": "https",
+        },
+      });
+      const res = handler(req);
+      const json = await res.json();
+      // Should use explicit override, ignoring both req.url and proxy headers
+      expect(json.resource).toBe("https://my-public-domain.com");
     });
   });
 });


### PR DESCRIPTION
This pull request adds robust support for detecting the public-facing URL and origin of requests, especially when running behind reverse proxies. It introduces new utility functions to correctly interpret proxy headers, updates authentication handlers to use these utilities or allow explicit URL overrides, and adds comprehensive tests for these scenarios.

**Proxy-aware URL detection and utilities:**

* Added `getPublicOrigin` and `getPublicUrl` utility functions in `src/lib/url.ts` to reconstruct the public-facing origin and URL from incoming requests, respecting `X-Forwarded-Host`, `X-Forwarded-Proto`, and `Forwarded` headers, or falling back to `req.url` if not present.
* Exported `getPublicOrigin` and `getPublicUrl` from the package entry point for external use.

**Authentication handler improvements:**

* Updated `protectedResourceHandler` in `src/auth/auth-metadata.ts` to use `getPublicUrl` for auto-detecting the public URL, and added an optional `resourceUrl` parameter for explicit overrides, improving support for deployments behind proxies or with unusual network setups. [[1]](diffhunk://#diff-af37ef7960e7a24fb62b62384ceb99ee1a518e7b50de6eb7ea6d724fe36f7138R2) [[2]](diffhunk://#diff-af37ef7960e7a24fb62b62384ceb99ee1a518e7b50de6eb7ea6d724fe36f7138R22-R53)
* Updated `withMcpAuth` in `src/auth/auth-wrapper.ts` to use the new `getPublicOrigin` utility and allow explicit `resourceUrl` overrides, ensuring correct construction of resource metadata URLs in proxied environments. [[1]](diffhunk://#diff-994f3db6b69c1282956094ded25938d5409eda526255d9f7254ef653a6bdd8d1R8) [[2]](diffhunk://#diff-994f3db6b69c1282956094ded25938d5409eda526255d9f7254ef653a6bdd8d1R26-R44)

**Testing and validation:**

* Added comprehensive tests to `tests/auth.test.ts` to verify correct behavior of public URL detection with various proxy header scenarios and explicit resource URL overrides.