### PR TITLE
chore: update @modelcontextprotocol/sdk peer dependency restriction to allow minor version updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "zod": "^3.25.50"
   },
   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "1.26.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "next": ">=13.0.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: 1.26.0
+        specifier: ^1.26.0
         version: 1.26.0(zod@3.25.50)
       chalk:
         specifier: ^5.3.0


### PR DESCRIPTION
- The `modelcontextprotocol/sdk` dependency has already released  version `1.29.0` ([npm package](https://www.npmjs.com/package/%40modelcontextprotocol/sdk)).
-  If an application depends on both `modelcontextprotocol/sdk` and `mcp-handler`, it cannot upgrade `modelcontextprotocol/sdk` due to the `peerDependencies` defined in `mcp-handler`.

This PR resolves that issue while still enforcing a minimum version of `1.26.0` for `modelcontextprotocol/sdk`, as defined in https://github.com/vercel/mcp-handler/pull/150