### PR TITLE
fix: allow streamable session id generator

### DIFF
--- a/src/handler/mcp-api-handler.ts
+++ b/src/handler/mcp-api-handler.ts
@@ -124,9 +124,10 @@ export type Config = {
   disableSse?: boolean;
 
   /**
-   * sessionIdGenerator for the streamable HTTP transport
+   * sessionIdGenerator for the streamable HTTP transport.
+   * Return a session ID to enable stateful Streamable HTTP sessions.
    */
-  sessionIdGenerator?: undefined;
+  sessionIdGenerator?: () => string;
 };
 
 /**

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { createMcpHandler } from "../src/index";
+
+describe("config", () => {
+  it("accepts a streamable HTTP session ID generator", () => {
+    const handler = createMcpHandler(
+      () => {},
+      {},
+      {
+        sessionIdGenerator: () => "session-id",
+      }
+    );
+
+    expect(typeof handler).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary
- Updates the config type so `sessionIdGenerator` accepts a function for Streamable HTTP sessions
- Adds a regression test that constructs a handler with a custom session ID generator

Fixes #149.

## Verification
- pnpm test tests/config.test.ts
- pnpm build