### PR TITLE
feat: export handler composition types

### DIFF
--- a/.changeset/export-handler-types.md
+++ b/.changeset/export-handler-types.md
@@ -1,0 +1,5 @@
+---
+"mcp-handler": patch
+---
+
+Export handler configuration, server initialization, and event types from the package entrypoint.

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -55,12 +55,64 @@ export { handler as GET, handler as POST, handler as DELETE };
 ## Configuration Options
 
 ```typescript
-interface Config {
+import type { Config } from "mcp-handler";
+
+const config: Config = {
+  redisUrl: process.env.REDIS_URL,
+  basePath: "/api",
+  maxDuration: 60,
+  verboseLogs: true,
+};
+```
+
+The exported `Config` type includes all handler options:
+
+```typescript
+type Config = {
   redisUrl?: string;    // Redis connection URL for pub/sub
   basePath?: string;    // Base path for MCP endpoints
   maxDuration?: number; // Maximum duration for SSE connections (seconds)
   verboseLogs?: boolean; // Enable debug logging
 }
+```
+
+## Composable Server Registration
+
+For larger servers, use `InitializeMcpServer` to split tool, prompt, and
+resource registration across files while keeping the same handler callback
+type:
+
+```typescript
+// app/api/[transport]/tools.ts
+import type { InitializeMcpServer } from "mcp-handler";
+import { z } from "zod";
+
+export const registerTools: InitializeMcpServer = (server) => {
+  server.registerTool(
+    "roll_dice",
+    {
+      title: "Roll Dice",
+      description: "Roll a dice with a specified number of sides.",
+      inputSchema: { sides: z.number().int().min(2) },
+    },
+    async ({ sides }) => {
+      const value = 1 + Math.floor(Math.random() * sides);
+      return {
+        content: [{ type: "text", text: `Rolled ${value}` }],
+      };
+    }
+  );
+};
+```
+
+```typescript
+// app/api/[transport]/route.ts
+import { createMcpHandler } from "mcp-handler";
+import { registerTools } from "./tools";
+
+const handler = createMcpHandler(registerTools, {}, { basePath: "/api" });
+
+export { handler as GET, handler as POST };
 ```
 
 ## Nuxt Usage

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -18,10 +18,14 @@ export type ServerOptions = McpServerOptions & {
   };
 };
 
+export type InitializeMcpServer =
+  | ((server: McpServer) => Promise<void>)
+  | ((server: McpServer) => void);
+
+export type { Config };
+
 export default function createMcpRouteHandler(
-  initializeServer:
-    | ((server: McpServer) => Promise<void>)
-    | ((server: McpServer) => void),
+  initializeServer: InitializeMcpServer,
   serverOptions?: ServerOptions,
   config?: Config
 ): (request: Request) => Promise<Response> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
 // Re-export the Next.js adapter
 export { default as createMcpHandler } from "./handler";
+export type { Config, InitializeMcpServer, ServerOptions } from "./handler";
+export type {
+  McpErrorEvent,
+  McpEvent,
+  McpEventType,
+  McpRequestEvent,
+  McpSessionEvent,
+} from "./lib/log-helper";
 
 /**
  * @deprecated Use withMcpAuth instead

--- a/tests/type-exports.test.ts
+++ b/tests/type-exports.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type {
+  Config,
+  InitializeMcpServer,
+  McpEvent,
+  ServerOptions,
+} from "../src";
+
+describe("public type exports", () => {
+  it("exports handler types that consumers can use to compose routes", () => {
+    const config: Config = {
+      basePath: "/api",
+      maxDuration: 60,
+      verboseLogs: false,
+    };
+
+    const serverOptions: ServerOptions = {
+      serverInfo: {
+        name: "typed-server",
+        version: "1.0.0",
+      },
+    };
+
+    const initializeServer: InitializeMcpServer = () => undefined;
+
+    const event: McpEvent = {
+      type: "SESSION_STARTED",
+      timestamp: Date.now(),
+      transport: "HTTP",
+    };
+
+    expect(config.basePath).toBe("/api");
+    expect(serverOptions.serverInfo?.name).toBe("typed-server");
+    expect(initializeServer).toBeTypeOf("function");
+    expect(event.type).toBe("SESSION_STARTED");
+  });
+});


### PR DESCRIPTION
## Summary
- exports `Config`, `ServerOptions`, `InitializeMcpServer`, and MCP event types from the package entrypoint
- documents how to split server registration across files with `InitializeMcpServer`
- adds a public type export regression test and patch changeset

Addresses #127.

## Issue triage
- #149 already has open PR #153 from EfeDurmaz16
- #129 already has open PR #155 from EfeDurmaz16
- #64 and #159 both cover elicitation and are broader transport/client capability work
- #99 is broader Streamable HTTP GET/DELETE notification support
- #128 is runtime abort handling and higher-risk than a type/docs contribution

## Verification
- pnpm test tests/type-exports.test.ts
- pnpm build
- pnpm test