### PR TITLE
fix: accept trailing slash endpoints

### DIFF
--- a/src/handler/mcp-api-handler.ts
+++ b/src/handler/mcp-api-handler.ts
@@ -148,6 +148,11 @@ function deriveEndpointsFromBasePath(basePath: string): {
     sseMessageEndpoint: `${normalizedBasePath}/message`,
   };
 }
+
+export function normalizeEndpointPath(pathname: string): string {
+  return pathname === "/" ? pathname : pathname.replace(/\/+$/, "");
+}
+
 /**
  * Calculates the endpoints for the MCP handler.
  * @param config - The configuration for the MCP handler.
@@ -321,7 +326,8 @@ export function initializeMcpApiHandler(
 
   return async function mcpApiHandler(req: Request, res: ServerResponse) {
     const url = new URL(req.url || "", "https://example.com");
-    if (url.pathname === streamableHttpEndpoint) {
+    const pathname = normalizeEndpointPath(url.pathname);
+    if (pathname === streamableHttpEndpoint) {
       if (req.method === "GET") {
         logger.log("Received GET MCP request");
         res.writeHead(405).end(
@@ -432,7 +438,7 @@ export function initializeMcpApiHandler(
           throw error;
         }
       }
-    } else if (url.pathname === sseEndpoint) {
+    } else if (pathname === sseEndpoint) {
       if (disableSse) {
         res.statusCode = 404;
         res.end("Not found");
@@ -707,7 +713,7 @@ export function initializeMcpApiHandler(
         await cleanup("error during setup");
         throw error;
       }
-    } else if (url.pathname === sseMessageEndpoint) {
+    } else if (pathname === sseMessageEndpoint) {
       if (disableSse) {
         res.statusCode = 404;
         res.end("Not found");

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateEndpoints } from '../src/handler/mcp-api-handler';
+import { calculateEndpoints, normalizeEndpointPath } from '../src/handler/mcp-api-handler';
 
 describe('calculateEndpoints', () => {
   it('derives all endpoints from basePath', () => {
@@ -86,5 +86,16 @@ describe('calculateEndpoints', () => {
       sseEndpoint: '/explicit/sse',
       sseMessageEndpoint: '/explicit/message',
     });
+  });
+});
+
+describe('normalizeEndpointPath', () => {
+  it('removes trailing slashes from non-root paths', () => {
+    expect(normalizeEndpointPath('/mcp/')).toBe('/mcp');
+    expect(normalizeEndpointPath('/api/mcp//')).toBe('/api/mcp');
+  });
+
+  it('preserves root path', () => {
+    expect(normalizeEndpointPath('/')).toBe('/');
   });
 });


### PR DESCRIPTION
## Summary

Allows MCP endpoint matching to tolerate trailing slash redirects, e.g. /mcp/ when Next.js trailingSlash is enabled.

Fixes #143.

## Changes

- Normalize request pathnames before comparing them with configured MCP endpoints
- Preserve root path behavior
- Apply the same normalization to streamable HTTP, SSE, and SSE message endpoints
- Add unit coverage for trailing slash normalization

## Verification

- pnpm install --frozen-lockfile
- pnpm test tests/mcp.test.ts
- pnpm build
- git diff --check