### PR TITLE
fix(cli): support version flag

### DIFF
--- a/.changeset/cli-version-flag.md
+++ b/.changeset/cli-version-flag.md
@@ -1,0 +1,5 @@
+---
+"mcp-handler": patch
+---
+
+Add `--version` support to the published CLI binaries.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,6 +4,7 @@ import { Command } from "commander";
 import fs from "node:fs/promises";
 import path from "node:path";
 import chalk from "chalk";
+import packageJson from "../../package.json";
 
 const program = new Command();
 
@@ -127,6 +128,7 @@ async function init() {
 program
   .name("mcp-handler")
   .description("Initialize MCP route handler in your Next.js project")
+  .version(packageJson.version)
   .action(init);
 
 program.parse();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "outDir": "./dist",
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true


### PR DESCRIPTION
## Summary

Adds standard `--version` / `-V` support to the published CLI binaries by wiring Commander to the package version.

## Problem

The published `mcp-handler@1.1.0` CLI already handles `--help`, but `--version` currently exits as an unknown option:

```text
$ mcp-handler --version
error: unknown option '--version'
```

That makes it harder for users and setup scripts to verify which CLI version is installed.

## Verification

- `corepack pnpm build`
- `corepack pnpm test` -> 30 tests passed
- `node dist/cli/index.js --help` -> exits 0 and shows `-V, --version`
- `node dist/cli/index.js --version` -> exits 0 and prints `1.1.0`
- `node dist/cli/index.js --definitely-not-a-real-flag` -> exits 1 with Commander unknown-option error
