### PR TITLE
deps: update 1.29.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A Vercel adapter for the Model Context Protocol (MCP), enabling real-time commun
 ## Installation
 
 ```bash
-npm install mcp-handler @modelcontextprotocol/sdk@1.26.0 zod@^3
+npm install mcp-handler @modelcontextprotocol/sdk@1.29.0 zod@^3
 ```
 
-> **Note**: Versions of `@modelcontextprotocol/sdk` prior to 1.26.0 have a security vulnerability. Use version 1.26.0 or later.
+> **Note**: Versions of `@modelcontextprotocol/sdk` prior to 1.29.0 have a security vulnerability. Use version 1.26.0 or later.
 
 ## Quick Start (Next.js)
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "zod": "^3.25.50"
   },
   "peerDependencies": {
-    "@modelcontextprotocol/sdk": "1.26.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "next": ">=13.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
my project relies on mcp-handler it uses @modelcontextprotocol/ext-apps which needs latest 1.29.0 version of @modelcontextprotocol/sdk@1.29.0, but mcp-handler is pinned to 1.26.0 so having hard time to update deps. Can mcp-handler be updated to use this? I like to stay up to date with latest mcp sdk 

thanks