### PR TITLE
fix: handle aborted responses without unhandled rejections

### DIFF
--- a/.changeset/fix-abort-crash.md
+++ b/.changeset/fix-abort-crash.md
@@ -1,0 +1,5 @@
+---
+'mcp-handler': patch
+---
+
+Handle aborted client requests without surfacing unhandled response-adapter rejections.

--- a/src/handler/server-response-adapter.ts
+++ b/src/handler/server-response-adapter.ts
@@ -76,7 +76,13 @@ export function createServerResponseAdapter(
         bufferedData.push(data);
         return true;
       }
-      controller.enqueue(data);
+      try {
+        controller.enqueue(data);
+      } catch {
+        // The stream may already be closed/errored if the client aborted the
+        // request before the response finished. Dropping the chunk is correct
+        // here; there is no socket left to write to.
+      }
       return true;
     };
 
@@ -126,7 +132,19 @@ export function createServerResponseAdapter(
       eventEmitter.emit('close');
     });
 
-    void fn(fakeServerResponse as ServerResponse);
+    // The handler runs fire-and-forget. If the client aborts before the
+    // response is fully sent, the underlying request rejects with
+    // "Error: aborted"; without this catch that rejection surfaces as a
+    // process-level unhandled rejection and crashes the server (issue #128).
+    Promise.resolve(fn(fakeServerResponse as ServerResponse)).catch(err => {
+      if (signal.aborted) {
+        // Expected when the client went away before we finished; nothing to do.
+        return;
+      }
+      // Otherwise this is a real handler error. Surface it without crashing the
+      // process so the abort guard above does not mask genuine failures.
+      console.error('mcp-handler: request handler error', err);
+    });
 
     void (async () => {
       const head = await writeHeadPromise;
@@ -135,11 +153,16 @@ export function createServerResponseAdapter(
         new ReadableStream({
           start(c) {
             controller = c;
-            for (const chunk of bufferedData) {
-              controller.enqueue(chunk);
-            }
-            if (shouldClose) {
-              controller.close();
+            try {
+              for (const chunk of bufferedData) {
+                controller.enqueue(chunk);
+              }
+              if (shouldClose) {
+                controller.close();
+              }
+            } catch {
+              // The client may have already aborted, in which case the stream
+              // is closed/errored. Flushing buffered data is then a no-op.
             }
           },
         }),
@@ -150,6 +173,13 @@ export function createServerResponseAdapter(
       );
 
       resolve(response);
-    })();
+    })().catch(err => {
+      // Building the Response should not reject, but guard the fire-and-forget
+      // IIFE so an unexpected rejection (e.g. during/after abort) cannot become
+      // an unhandled rejection that crashes the server.
+      if (!signal.aborted) {
+        console.error('mcp-handler: response builder error', err);
+      }
+    });
   });
 }

--- a/tests/server-response-adapter.test.ts
+++ b/tests/server-response-adapter.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import type { ServerResponse } from 'node:http';
+import { createServerResponseAdapter } from '../src/handler/server-response-adapter';
+
+/**
+ * Regression tests for vercel/mcp-handler#128:
+ * "Server is crashing if the client aborts the request before response is sent".
+ *
+ * The adapter previously fired the handler and the async Response builder as
+ * fire-and-forget (`void fn(...)` / `void (async () => ...)()`) with no
+ * `.catch`, so a rejection on an aborted request surfaced as a process-level
+ * unhandled rejection. It also enqueued to / closed the stream controller
+ * without guarding for the case where the underlying socket was already gone.
+ */
+describe('createServerResponseAdapter abort handling', () => {
+  /**
+   * Collect unhandled rejections during the body of `run`. Returns any that
+   * fired. Without the fix, an aborted handler rejection lands here.
+   */
+  async function collectUnhandledRejections(
+    run: () => Promise<void>
+  ): Promise<unknown[]> {
+    const captured: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      captured.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      await run();
+      // Give any queued microtasks / fire-and-forget promises a chance to
+      // reject and surface as unhandled rejections.
+      await new Promise(resolve => setTimeout(resolve, 50));
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+    return captured;
+  }
+
+  it('does not produce an unhandled rejection when the handler rejects after client abort', async () => {
+    const controller = new AbortController();
+
+    const rejections = await collectUnhandledRejections(async () => {
+      const responsePromise = createServerResponseAdapter(
+        controller.signal,
+        async (res: ServerResponse) => {
+          // Handler writes a head, then the client aborts before the body is
+          // fully sent, then the handler rejects (mirrors the "Error: aborted"
+          // path in the issue stack trace).
+          res.writeHead(200, { 'content-type': 'text/event-stream' });
+          controller.abort();
+          await new Promise(resolve => setTimeout(resolve, 0));
+          throw new Error('aborted');
+        }
+      );
+
+      // The adapter should still resolve a Response (head was written) and must
+      // not throw at the call site.
+      const response = await responsePromise;
+      expect(response).toBeInstanceOf(Response);
+    });
+
+    expect(rejections).toEqual([]);
+  });
+
+  it('does not throw when the response stream is enqueued/closed after abort', async () => {
+    const controller = new AbortController();
+
+    const rejections = await collectUnhandledRejections(async () => {
+      const response = await createServerResponseAdapter(
+        controller.signal,
+        (res: ServerResponse) => {
+          res.writeHead(200);
+          res.write('chunk-before-abort');
+          // Socket goes away.
+          controller.abort();
+          // Writing/closing after abort must not throw or reject.
+          res.write('chunk-after-abort');
+          res.end();
+        }
+      );
+
+      expect(response).toBeInstanceOf(Response);
+    });
+
+    expect(rejections).toEqual([]);
+  });
+
+  it('still resolves a normal (non-aborted) response correctly', async () => {
+    const controller = new AbortController();
+
+    const response = await createServerResponseAdapter(
+      controller.signal,
+      (res: ServerResponse) => {
+        res.writeHead(201, { 'x-test': 'ok' });
+        res.write('hello');
+        res.end();
+      }
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(201);
+    expect(response.headers.get('x-test')).toBe('ok');
+    expect(await response.text()).toBe('hello');
+  });
+});


### PR DESCRIPTION
Client aborts could leave `mcp-handler` with an unhandled rejection if the request handler or response builder failed after the response stream was already gone.
This catches those late failures, ignores expected abort-driven errors when the request signal is aborted, and keeps non-abort failures logged instead of surfacing as process-level unhandled rejections. It also guards late stream writes and closes after abort.
I added regression coverage for the abort path, late writes after abort, and the normal response path. The focused adapter test passes, the full test suite passes 33/33, and build, TypeScript, and changeset status are clean.

Fixes #128