### PR TITLE
fix: sign changesets release commits via GitHub API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
           version: pnpm version-packages
           commit: "chore: update package versions"
           title: "chore: update package versions"
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}


### PR DESCRIPTION
## Summary

- switch Changesets to `github-api` commit mode
- ensure generated version commits and tags are GPG-signed and pass the enterprise signed-commit ruleset

## Validation

- parsed `.github/workflows/release.yml` as YAML
- `git diff --check` passes

This fixes the GH013 failure in Release run 30478071607.