### PR TITLE
fix: publish releases with npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,21 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@11
+
+      - name: Verify publishing runtime
+        run: |
+          node --version
+          npm --version
+
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-setup
@@ -48,4 +63,3 @@ jobs:
           commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PULL_REQUESTS }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Built on MCP SDK v2, serving the **2026-07-28** MCP specification (stateless pro
 ## Installation
 
 ```bash
-npm install mcp-handler @modelcontextprotocol/server zod
+npm install mcp-handler@^2 @modelcontextprotocol/server@^2 zod@^4
 ```
 
 > **Note**: `mcp-handler` 2.x requires the MCP SDK v2 packages (`@modelcontextprotocol/server` ^2.0.0), zod ^4.2.0, and Node.js 20+. If you're on `@modelcontextprotocol/sdk` 1.x, use `mcp-handler` 1.x.


### PR DESCRIPTION
## Summary

- configure the stable release workflow with Node 24 and npm 11
- publish through npm trusted publishing rather than `NPM_TOKEN_ELEVATED`
- pin the documented install command to compatible v2/v4 major ranges

## Validation

- parsed `.github/workflows/release.yml` as YAML
- confirmed no npm auth token remains in `release.yml`
- `git diff --check` passes

## Required npm setting

Before merging the `mcp-handler@2.0.0` release PR (#174), change the package trusted-publisher workflow filename on npm from `release-snapshot.yml` to `release.yml`.