### PR TITLE
fix(auth): check token expiry before scopes in withMcpAuth

### DIFF
--- a/src/auth/auth-wrapper.ts
+++ b/src/auth/auth-wrapper.ts
@@ -74,6 +74,14 @@ export function withMcpAuth(
         return handler(req);
       }
 
+      // Check if the token is expired before authorizing it. An expired token
+      // is invalid_token (401) per RFC 6750 §3.1, so it has to be reported that
+      // way even when scopes are also missing: insufficient_scope (403) tells
+      // the client its permissions are wrong and it will not refresh.
+      if (authInfo.expiresAt && authInfo.expiresAt < Date.now() / 1000) {
+        throw new OAuthError(OAuthErrorCode.InvalidToken, "Token has expired");
+      }
+
       // Check if token has the required scopes (if any)
       if (requiredScopes?.length) {
         const hasAllScopes = requiredScopes.every((scope) =>
@@ -86,11 +94,6 @@ export function withMcpAuth(
             "Insufficient scope",
           );
         }
-      }
-
-      // Check if the token is expired
-      if (authInfo.expiresAt && authInfo.expiresAt < Date.now() / 1000) {
-        throw new OAuthError(OAuthErrorCode.InvalidToken, "Token has expired");
       }
 
       // Set auth info on the request object after successful verification

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { protectedResourceHandler } from "../src/index";
+import { describe, it, expect, vi } from "vitest";
+import { protectedResourceHandler, withMcpAuth } from "../src/index";
 
 describe("auth", () => {
   describe("resource metadata URL to resource identifier mapping", () => {
@@ -135,6 +135,70 @@ describe("auth", () => {
       const json = await res.json();
       // Should use explicit override, ignoring both req.url and proxy headers
       expect(json.resource).toBe("https://my-public-domain.com");
+    });
+  });
+
+  describe("withMcpAuth token expiry and scope checks", () => {
+    const ok = () => new Response("ok");
+
+    function buildHandler(requiredScopes?: string[]) {
+      return withMcpAuth(ok, (_req, bearer) => {
+        if (!bearer) return undefined;
+        const [scopes, expiresAt] = bearer.split("|");
+        return {
+          token: bearer,
+          clientId: "c1",
+          scopes: scopes.split(","),
+          expiresAt: expiresAt ? Number(expiresAt) : undefined,
+        };
+      }, { required: true, requiredScopes });
+    }
+
+    function request(token: string) {
+      return new Request("https://example.com/mcp", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    }
+
+    it("returns 401 for an expired token even when scopes are missing", async () => {
+      const handler = buildHandler(["admin"]);
+      const expired = Math.floor(Date.now() / 1000) - 60;
+      const res = await handler(request(`read|${expired}`));
+      expect(res.status).toBe(401);
+      const challenge = res.headers.get("WWW-Authenticate") ?? "";
+      expect(challenge).toContain("invalid_token");
+      expect(challenge).not.toContain("insufficient_scope");
+    });
+
+    it("returns 403 for a live token that lacks required scopes", async () => {
+      const handler = buildHandler(["admin"]);
+      const future = Math.floor(Date.now() / 1000) + 3600;
+      const res = await handler(request(`read|${future}`));
+      expect(res.status).toBe(403);
+      const challenge = res.headers.get("WWW-Authenticate") ?? "";
+      expect(challenge).toContain("insufficient_scope");
+    });
+
+    it("passes through when token is live and scopes match", async () => {
+      const handler = buildHandler(["read"]);
+      const future = Math.floor(Date.now() / 1000) + 3600;
+      const res = await handler(request(`read|${future}`));
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 401 for an expired token with no required scopes", async () => {
+      const handler = buildHandler();
+      const expired = Math.floor(Date.now() / 1000) - 60;
+      const res = await handler(request(`read|${expired}`));
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 when no authorization is provided and auth is required", async () => {
+      const handler = buildHandler();
+      const res = await handler(
+        new Request("https://example.com/mcp"),
+      );
+      expect(res.status).toBe(401);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Expired tokens that also lack a required scope now correctly return `401 invalid_token` instead of `403 insufficient_scope`
- Moves the `expiresAt` check above the `requiredScopes` check in `withMcpAuth` so expiry is always evaluated first, per [RFC 6750 §3.1](https://datatracker.ietf.org/doc/html/rfc6750#section-3.1)
- Adds regression tests for expiry-vs-scope ordering, live+unscoped, live+scoped, expired-no-scopes-required, and missing-auth paths

Fixes #181

## Why it matters

`401 invalid_token` tells an MCP client its token is no longer valid — the client should refresh or re-authenticate. `403 insufficient_scope` tells the client it has the wrong permissions — the client will **not** refresh and may surface a misleading "insufficient permissions" error. When both conditions are true, RFC 6750 requires the expiry to win.

## Test plan

- [x] New test: expired + missing scope → 401 `invalid_token` (was 403 before fix)
- [x] New test: live + missing scope → 403 `insufficient_scope` (unchanged)
- [x] New test: live + matching scope → 200 (unchanged)
- [x] New test: expired + no required scopes → 401 (unchanged)
- [x] New test: no auth + required → 401 (unchanged)
- [x] Full suite passes 29/29 (`vitest run`)